### PR TITLE
test: fix type checks

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    // https://github.com/denoland/deno/issues/26485
+    "isolatedDeclarations": false,
+  },
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "deno test --watch",
     "test": "deno test 'src/**/*.test.ts'",
     "test:node": "node --import tsx --test 'src/**/*.test.ts'",
-    "types": "deno check '**/*.ts'",
+    "types": "deno check --config=deno.jsonc '**/*.ts' && tsc",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint",

--- a/src/SubscribableValueErrorState.ts
+++ b/src/SubscribableValueErrorState.ts
@@ -11,6 +11,10 @@ import {
 import {ValueErrorStates} from './ValueErrorStates.ts';
 
 /**
+ * Manages different ValueErrorState tuples over time, and provides synchronous access to the current value, error and state.
+ *
+ * The subclasses differ in how the promise(s) triggering the changed values are created.
+ *
  * By providing a factory for a `Subject` (`Observer` + `Subscribable`),
  * updates of `valueErrorState` can be subscribed to.
  *

--- a/src/SubscribableValueErrorState.ts
+++ b/src/SubscribableValueErrorState.ts
@@ -24,11 +24,17 @@ export class SubscribableValueErrorState<
   T,
   E = unknown,
 > extends ValueErrorStates<T, E> {
+  override readonly initial: Readonly<T>;
+
+  protected _subjectFactory: SubjectFactory<ValueErrorState<T>>;
+
   constructor(
-    override readonly initial: Readonly<T>,
-    protected _subjectFactory: SubjectFactory<ValueErrorState<T>>,
+    initial: Readonly<T>,
+    _subjectFactory: SubjectFactory<ValueErrorState<T>>,
   ) {
     super(initial);
+    this._subjectFactory = _subjectFactory;
+    this.initial = initial;
   }
 
   protected _subject: Subject<ValueErrorState<T, E>> | undefined;

--- a/src/ValueErrorStates.ts
+++ b/src/ValueErrorStates.ts
@@ -21,7 +21,10 @@ import {
  * The subclasses differ in how the promise(s) triggering the changed values are created.
  */
 export class ValueErrorStates<T, E = unknown> {
-  constructor(readonly initial: Readonly<T>) {
+  readonly initial: Readonly<T>;
+
+  constructor(initial: Readonly<T>) {
+    this.initial = initial;
     this.#valueErrorState = this.READY = Ready(initial);
   }
   /**

--- a/src/ValueErrorStates.ts
+++ b/src/ValueErrorStates.ts
@@ -18,7 +18,7 @@ import {
 /**
  * Manages different ValueErrorState tuples over time, and provides synchronous access to the current value, error and state.
  *
- * The subclasses differ in hpw the promise(s) triggering the changed values are created.
+ * The subclasses differ in how the promise(s) triggering the changed values are created.
  */
 export class ValueErrorStates<T, E = unknown> {
   constructor(readonly initial: Readonly<T>) {

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -19,8 +19,7 @@ import {usePlugin} from '@assertive-ts/core';
 import {SinonPlugin} from '@assertive-ts/sinon';
 usePlugin(SinonPlugin);
 
-// eslint-disable-next-line @typescript-eslint/no-inferrable-types
-export const isDeno: boolean = !!globalThis.Deno;
+export const isDeno: boolean = 'Deno' in globalThis;
 type Fn = () => void;
 export const describe = (message: string, fn: Fn): void => {
   if (isDeno) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,7 +46,8 @@
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // value of allowJs is ignored by deno!
+    // "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 


### PR DESCRIPTION
- disable `isolatedDeclarations` when running deno checks
- additionally run `tsc` to catch `isolatedDeclarations` issues in CI and keep compatibility
- more "dynamic" check for Deno, to make `tsc` happy
- convert constructor parameter declarations to fields