### PR TITLE
ci: fix publish while keeping type checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
       - run: pnpm test:node
       - run: pnpm lint
       - run: pnpm format:check
+      - run: pnpm pubdry
 
   publish:
     if: github.event_name == 'push' && github.ref_name == 'main'
@@ -44,4 +45,4 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      - run: deno publish
+      - run: pnpm pub

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    // https://github.com/denoland/deno/issues/26485
+    // https://github.com/denoland/deno/issues/26485 =(
     "isolatedDeclarations": false,
   },
 }

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,0 @@
-{
-  "name": "@karfau/cached-promise",
-  "version": "0.1.0",
-  "license": "MIT",
-  "exports": "./src/index.ts"
-}

--- a/jsr.jsonc
+++ b/jsr.jsonc
@@ -1,0 +1,24 @@
+{
+  "name": "@karfau/cached-promise",
+  "version": "0.2.0",
+  "license": "MIT",
+  "exports": "./src/index.ts",
+  "exclude": [
+    // workflow files
+    ".github",
+    // "hidden" config files that are part of the repo
+    ".*",
+    "test",
+    // *.test.ts files they show as empty files in the JSR file explorer
+    "src/**/*.test.ts",
+    // eslint config
+    "eslint*",
+    // all the little config files including package.json containing potential npm config
+    "*.json",
+    // jsr.jsonc is still published
+    "*.jsonc",
+    // dependencies are set to pinned versions in the files:
+    // https://jsr.io/@karfau/cached-promise/0.1.0/src/Subject.ts#L2
+    "pnpm-lock.yaml",
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "dev": "deno test --watch",
     "test": "deno test 'src/**/*.test.ts'",
     "test:node": "node --import tsx --test 'src/**/*.test.ts'",
-    "types": "deno check --config=deno.jsonc '**/*.ts' && tsc",
+    "types": "(set -x; deno check '**/*.ts' && tsc --listFiles)",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "prepare": "husky"
+    "prepare": "husky",
+    "pub": "deno publish --config jsr.jsonc --no-check",
+    "pubdry": "pnpm pub --dry-run --allow-dirty"
   },
   "keywords": [],
   "author": "Christian Bewernitz",


### PR DESCRIPTION
- publish without checks since they are checked before
- point publish to `jsr.jsonc`
- exclude irrelevant files from publishing
- improve output of `pnpm types`