### PR TITLE
feat: implement SubscribablePromises

### DIFF
--- a/src/SubscribablePromises.test.ts
+++ b/src/SubscribablePromises.test.ts
@@ -1,0 +1,221 @@
+import {assertType, type IsExact} from '@std/testing/types';
+import {spy} from 'sinon';
+import {BehaviorSubject} from 'rxjs';
+import {describe, expect, it} from '../test/runner.ts';
+import {SubscribablePromises} from './SubscribablePromises.ts';
+import {
+  Fulfilled,
+  Loading,
+  PState,
+  Ready,
+  type ValueErrorState,
+} from './ValueErrorState.ts';
+
+const givenAResolvedSubscribablePromises = async <T>(
+  initial: T,
+  fulfilled: T,
+) => {
+  const impl = spy(async () => Promise.resolve(fulfilled));
+
+  const it = new SubscribablePromises(
+    initial,
+    (current: ValueErrorState<T>) => new BehaviorSubject(current),
+  );
+  const result = await it.set(impl());
+
+  expect(result).toBeEqual(Fulfilled(fulfilled));
+  expect(it.valueErrorState).toBe(result);
+  return {initial, impl, it, fulfilled};
+};
+
+function expectRejectedWithError<T>(it: SubscribablePromises<T>) {
+  expect(it.state).toBeEqual(PState.rejected);
+  expect(it.error).toBeInstanceOf(Error);
+  expect(it.value).toBeEqual(it.initial);
+}
+
+describe('SubscribablePromises', () => {
+  describe('from and reset update stateValue: [PState, value | error]', () => {
+    it('should be ready >-set-> loading(1) >-set-> loading(2) >-resolves(1)-> loading(2) >-resolves(2)-> resolved(2)', async () => {
+      let counter = 0;
+      const subjectFactory = (current: ValueErrorState<number | undefined>) =>
+        new BehaviorSubject(current);
+      const impl = async () => Promise.resolve(++counter);
+
+      const it = new SubscribablePromises<number | undefined>(
+        counter,
+        subjectFactory,
+      );
+      expect(it.isReady).toBe(true);
+
+      const first = impl();
+      const setFirst = it.set(first);
+      expect(it.isReady).toBe(false);
+      expect(it.state).toBeEqual(PState.loading);
+      expect(it.isLoading).toBe(true);
+
+      const second = impl();
+      const setSecond = it.set(second);
+      expect(it.state).toBeEqual(PState.loading);
+      await first;
+      expect(it.state).toBeEqual(PState.loading);
+      await second;
+      expect(it.valueErrorState).toBeEqual(Fulfilled(2));
+      await expect(setSecond).toBeResolvedWith(Fulfilled(2));
+      await expect(first).toBeResolvedWith(1);
+      await expect(second).toBeResolvedWith(2);
+      // the first promise is not affecting the state, sine it is not the current promise.
+      // so it resolved to the loading state when it was done, this is never going to change.
+      await expect(setFirst).toBeResolvedWith(Loading(0));
+    });
+    it('should be ready >-set-> loading(1) >-reset-> ready >-resolves(1)-> ready', async () => {
+      let counter = 0;
+      const subjectFactory = (current: ValueErrorState<number | undefined>) =>
+        new BehaviorSubject(current);
+      const impl = async () => Promise.resolve(++counter);
+
+      const it = new SubscribablePromises<number | undefined>(
+        counter,
+        subjectFactory,
+      );
+      expect(it.isReady).toBe(true);
+
+      const first = impl();
+      const setFirst = it.set(first);
+      expect(it.isReady).toBe(false);
+      expect(it.state).toBeEqual(PState.loading);
+      expect(it.isLoading).toBe(true);
+
+      it.reset();
+
+      await expect(first).toBeResolvedWith(1);
+      // the promise is not affecting the state, since the state is not `loading`.
+      // so it resolves to the ready state when it is done, this is never going to change.
+      await expect(setFirst).toBeResolvedWith(Ready(0));
+      expect(it.state).toBeEqual(PState.ready);
+      expect(it.valueErrorState).toBeEqual(Ready(0));
+    });
+    it('should be ... resolved >-set-> loading(2) >-resolve-> resolved', async () => {
+      const {impl, it, fulfilled} = await givenAResolvedSubscribablePromises(
+        false,
+        true,
+      );
+
+      const second = it.set(impl());
+      expect(it.valueErrorState).toBeEqual(Loading(fulfilled));
+
+      const secondResult = await second;
+      expect(secondResult).toBeEqual(Fulfilled(fulfilled));
+      expect(it.valueErrorState).toBeEqual(secondResult);
+    });
+    it('should be ... resolved >-reset-> ready >-set-> loading(2) >-resolve-> resolved', async () => {
+      const {initial, impl, it, fulfilled} =
+        await givenAResolvedSubscribablePromises(false, true);
+
+      it.reset();
+      expect(it.valueErrorState).toBeEqual(it.READY);
+
+      const second = it.set(impl());
+      expect(it.valueErrorState).toBeEqual([
+        initial,
+        undefined,
+        PState.loading,
+      ]);
+
+      const secondResult = await second;
+      expect(secondResult).toBeEqual(Fulfilled(fulfilled));
+      expect(it.valueErrorState).toBeEqual(secondResult);
+    });
+    it('should be ready >-set-> loading(1) >-reject-> rejected >-set-> loading(2) >-reject-> rejected', async () => {
+      const initial = false;
+      const subjectFactory = (current: ValueErrorState<boolean>) =>
+        new BehaviorSubject(current);
+      const reason = new Error('promise rejected in test');
+      const impl = async () => Promise.reject(reason);
+
+      const it = new SubscribablePromises(initial, subjectFactory);
+
+      const first = it.set(impl());
+      expect(it.valueErrorState).toBeEqual(Loading(initial));
+
+      await expect(first).toBeRejectedWith(reason);
+      expectRejectedWithError(it);
+
+      const second = it.set(impl());
+      expect(it.valueErrorState).toBeEqual(Loading(initial));
+
+      await expect(second).toBeRejectedWith(reason);
+      expectRejectedWithError(it);
+    });
+  });
+  describe('valueErrorState$', () => {
+    it('should push all possible states', async () => {
+      const subjectFactory = (current: ValueErrorState<undefined>) =>
+        new BehaviorSubject(current);
+
+      const it = new SubscribablePromises<undefined>(undefined, subjectFactory);
+
+      const states: PState[] = [];
+      const first = it.set(Promise.resolve(undefined)); // -> loading(1)
+      const observable = it.getValueErrorState$();
+      expect(it.state).toBe(PState.loading);
+
+      observable.subscribe({
+        next: ([_, __, state]: ValueErrorState<undefined>) => {
+          states.push(state);
+        },
+      });
+
+      await first; // -> resolved
+
+      const reason = new Error('set test');
+      await expect(
+        it.set(Promise.reject(reason)), // -> loading(2)
+      ).toBeRejectedWith(reason);
+      // -> rejected
+
+      it.reset(); // -> ready
+
+      expect(states).toBeEqual([
+        PState.loading,
+        PState.fulfilled,
+        PState.loading,
+        PState.rejected,
+        PState.ready,
+      ] as const);
+    });
+    it('should be stable', () => {
+      const subjectFactory = (current: ValueErrorState<undefined>) =>
+        new BehaviorSubject(current);
+      const it = new SubscribablePromises(undefined, subjectFactory);
+
+      const observable = it.getValueErrorState$();
+
+      expect(it.getValueErrorState$()).toBe(observable);
+    });
+  });
+
+  it('should not call the subjectFactory until subject is requested', () => {
+    const subjectFactory = spy(
+      (current: ValueErrorState<number>) => new BehaviorSubject(current),
+    );
+
+    const it = new SubscribablePromises(0, subjectFactory);
+
+    const loading = it._setValueErrorState(Loading(1));
+    assertType<IsExact<typeof loading, Loading<number>>>(true);
+
+    expect(subjectFactory).toNeverBeCalled();
+
+    const requested = it.getValueErrorState$();
+
+    expect(subjectFactory).toBeCalledOnce().toHaveArgs(loading);
+
+    const next = spy((_: ValueErrorState<number>) => undefined);
+    requested.subscribe({next});
+    expect(next).toBeCalledOnce().toHaveArgs(loading);
+
+    const fulfilled = it._setValueErrorState(Fulfilled(2));
+    expect(next).toBeCalledTwice().toHaveArgs(fulfilled);
+  });
+});

--- a/src/SubscribablePromises.ts
+++ b/src/SubscribablePromises.ts
@@ -1,0 +1,94 @@
+import {
+  Fulfilled,
+  Loading,
+  type Ready,
+  Rejected,
+  type ValueErrorState,
+} from './ValueErrorState.ts';
+import {SubscribableValueErrorState} from './SubscribableValueErrorState.ts';
+
+export type AsyncValueErrorState<T, E = unknown> = Promise<
+  ValueErrorState<T, E>
+>;
+export interface SetOptions<T, E = unknown> {
+  loadingValue?: T;
+  onError?: (error: E) => void;
+}
+
+/**
+ * Provides a stable observable for a series of "independently created" promises.
+ * The current ValueErrorState is updated when the current promise is `set`, is fulfilled or rejected.
+ *
+ * The only thing the promises need to have in common is the type.
+ */
+export class SubscribablePromises<
+  T,
+  E = unknown,
+> extends SubscribableValueErrorState<T, E> {
+  protected _current: Promise<T> | undefined;
+
+  /**
+   * Provides access to the last promise that has been `set` until it settles
+   * or is reset.
+   */
+  public get(): Promise<T> | undefined {
+    return this._current;
+  }
+
+  /**
+   * Updates the current value, error and state according to the state of the Promise.
+   * This method assumes that the async action has already been triggered,
+   * so it switches to the `loading` state right away.
+   *
+   * When the Promise fulfills or rejects,
+   * the value, error and state are updated accordingly.
+   *
+   * Only the last promise that was passed is able to modify the state:
+   * When this method is called with a new promise while another one has not settled,
+   * the first promise is ignored when it fulfills.
+   * When calling `reset` while the current promise has not settled,
+   * the state will change to `ready` and the result of the promise is ignored.
+   * (The Promise that was previously returned will fulfill with the initial value.)
+   *
+   * @param p the promise that should be used to update the state of this instance.
+   * @param loadingValue the value to use during the loading state, defaults to `initial`.
+   * @param onError a callback that will be invoked before the returned Promise rejects.
+   *
+   * @returns a promise that fulfills with the current ValueErrorState,
+   *          at the point in time when `p` is fulfilled.
+   *          If `p` rejects, the returned Promise also rejects with the same error.
+   *          (The value, error and state of this instance are still updated.)
+   */
+  async set(
+    p: Promise<T>,
+    {loadingValue = this.value, onError}: SetOptions<T, E> = {},
+  ): AsyncValueErrorState<T, E> {
+    this._current = p;
+    this._setValueErrorState(Loading(loadingValue));
+    try {
+      const awaited = await p;
+      if (this._current === p && this.isLoading) {
+        return this._setValueErrorState(Fulfilled(awaited));
+      }
+    } catch (error: unknown) {
+      if (this._current === p && this.isLoading) {
+        onError?.(error as E);
+        this._setValueErrorState(Rejected(this.initial, error as E));
+        throw error;
+      }
+    } finally {
+      if (this._current === p) {
+        this._current = undefined;
+      }
+    }
+    // fulfills the promise with the current value, error and state,
+    // in case a new promise has been set,
+    // at the point in time `p` settles, if it ever does.
+    return this.valueErrorState;
+  }
+
+  public override reset(): Ready<T> {
+    this._current = undefined;
+    return super.reset();
+  }
+}

--- a/src/ValueErrorState.test.ts
+++ b/src/ValueErrorState.test.ts
@@ -30,7 +30,7 @@ it('should correctly create Loading', () => {
   expect(isPending(state)).toBe(true);
   expect(isSettled(state)).toBe(false);
 });
-it('should correctly creat Fulfilled', () => {
+it('should correctly create Fulfilled', () => {
   const input = {};
   const [value, error, state] = Fulfilled(input);
   expect(value).toBe(input);
@@ -39,7 +39,7 @@ it('should correctly creat Fulfilled', () => {
   expect(isSettled(state)).toBe(true);
   expect(isPending(state)).toBe(false);
 });
-it('should correctly creat Rejected', () => {
+it('should correctly create Rejected', () => {
   const input = {};
   const reason = 'no way';
   const [value, error, state] = Rejected(input, reason);

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -21,6 +21,7 @@ usePlugin(SinonPlugin);
 
 export const isDeno: boolean = 'Deno' in globalThis;
 type Fn = () => void;
+type AsyncFn = () => Promise<void>;
 export const describe = (message: string, fn: Fn): void => {
   if (isDeno) {
     describeD(message, fn);
@@ -28,7 +29,7 @@ export const describe = (message: string, fn: Fn): void => {
     void describeN(message, fn);
   }
 };
-export const it = (message: string, fn: Fn): void => {
+export const it = (message: string, fn: Fn | AsyncFn): void => {
   if (isDeno) {
     itD(message, fn);
   } else {


### PR DESCRIPTION
Provides a stable observable for a series of "independently created" promises. The current `ValueErrorState` is updated when the current promise is `set`, fulfills or rejects. 

The only thing the promises need to have in common is the type.