### PR TITLE
feat: implement basic CachedPromise

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,10 @@ export default tseslint.config(eslint.configs.recommended, {
     importPlugin.flatConfigs.typescript,
   ],
   rules: {
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {fixStyle: 'inline-type-imports'},
+    ],
     '@typescript-eslint/no-unused-vars': [
       'error',
       {
@@ -31,10 +35,6 @@ export default tseslint.config(eslint.configs.recommended, {
         ignoreRestSiblings: true,
         reportUsedIgnorePattern: true,
       },
-    ],
-    '@typescript-eslint/consistent-type-imports': [
-      'error',
-      {fixStyle: 'inline-type-imports'},
     ],
   },
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "types": "pnpm run --aggregate-output /^types:.*/",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "knip": "knip",
+    "knip": "knip && knip --production",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:node": "node --test 'src/**/*.test.ts'",
     "test": "pnpm run --aggregate-output /^test:.*/",
     "checks": "pnpm types && pnpm lint && pnpm knip",
-    "types:deno": "set -x; deno check '**/*.ts'",
+    "types:deno": "(set -x; deno check '**/*.ts')",
     "types:node": "tsc --listFiles",
     "types": "pnpm run --aggregate-output /^types:.*/",
     "format": "prettier --write .",

--- a/src/CachedPromise.test.ts
+++ b/src/CachedPromise.test.ts
@@ -1,0 +1,126 @@
+import {spy} from 'sinon';
+import {describe, expect, it} from '../test/runner.ts';
+import {behaviorSubject} from '../test/behaviorSubject.ts';
+import {CachedPromise} from './CachedPromise.ts';
+import {
+  Fulfilled,
+  Loading,
+  PState,
+  Ready,
+  Rejected,
+} from './ValueErrorState.ts';
+
+describe('CachedPromise', () => {
+  it('should reset the cache when loading', async () => {
+    const it = new CachedPromise(
+      () => Promise.resolve({}),
+      undefined,
+      behaviorSubject,
+    );
+    const p = it.request();
+    expect(it.state).toBeEqual(PState.loading);
+    it.reset();
+    const resetVES = it.valueErrorState;
+    expect(resetVES).toBeEqual(Ready(it.initial));
+    await expect(p).toBeResolvedWith(resetVES);
+  });
+  it('should reset the cache when fulfilled', async () => {
+    const it = new CachedPromise(
+      () => Promise.resolve({}),
+      undefined,
+      behaviorSubject,
+    );
+    const p = it.request();
+    expect(it.state).toBeEqual(PState.loading);
+    it.reset();
+    expect(it._cache).toBeUndefined();
+    const resetVES = it.valueErrorState;
+    expect(resetVES).toBeEqual(Ready(it.initial));
+    await expect(p).toBeResolvedWith(resetVES);
+  });
+  describe('impl without argument', () => {
+    it(`should start in ready state, 
+        all requests trigger impl only once and resolve with same ValueErrorState, 
+        the value being the awaited value from impl, keeping a reference to the cached promise`, async () => {
+      const initial = {},
+        resolved = {};
+      const impl = spy(() => Promise.resolve(resolved));
+      const it = new CachedPromise(impl, initial, behaviorSubject);
+      expect(it.value).toBe(initial);
+      expect(impl).toBeCalled(0);
+      expect(it._cache).toBeUndefined();
+      expect(it.valueErrorState).toBeEqual(Ready(initial));
+      expect(it.value).toBe(initial);
+
+      const first = it.request();
+      const firstLoadingVES = it.valueErrorState;
+      expect(impl).toBeCalled(1);
+      expect(it.value).toBe(initial);
+      expect(firstLoadingVES).toBeEqual(Loading(initial));
+      const firstCache = it._cache;
+      expect(firstCache).toBeInstanceOf(Promise);
+
+      const second = it.request();
+      expect(impl).toBeCalled(1);
+      expect(it.valueErrorState).toBe(firstLoadingVES);
+      expect(it._cache).toBe(firstCache);
+
+      const firstAwaited = await first;
+      expect(firstAwaited)
+        .toBe(it.valueErrorState)
+        .toBeEqual(Fulfilled(resolved));
+      await expect(second).toBeResolvedWith(firstAwaited);
+      expect(it._cache).toBe(firstCache);
+    });
+    it('should skip loading state and reject on each request when impl throws instead of rejecting', async () => {
+      const error = new Error('from impl');
+      const impl = spy(() => {
+        throw error;
+      });
+      const it = new CachedPromise(impl, undefined, behaviorSubject);
+
+      const first = it.request();
+      const firstVES = it.valueErrorState;
+      expect(firstVES).toBeEqual(Rejected(undefined, error));
+      expect(it._cache).toBeUndefined();
+      expect(impl).toBeCalled(1);
+
+      const second = it.request();
+      expect(impl).toBeCalled(2);
+      expect(it.valueErrorState)
+        .not.toBe(firstVES)
+        .toBeEqual(Rejected(undefined, error));
+
+      await expect(first).toBeRejectedWith(error);
+      await expect(second).toBeRejectedWith(error);
+    });
+    it('should transition from loading to rejected when impl rejects', async () => {
+      const error = new Error('from impl');
+      const impl = spy(async () => Promise.reject(error));
+      const it = new CachedPromise(impl, undefined, behaviorSubject);
+
+      const first = it.request();
+      const firstVES = it.valueErrorState;
+      expect(firstVES).toBeEqual(Loading(undefined));
+      expect(it._cache).toBeInstanceOf(Promise);
+
+      const firstCache = it._cache;
+      expect(firstCache).toBeInstanceOf(Promise);
+
+      const second = it.request();
+      expect(impl).toBeCalled(1);
+      expect(it.valueErrorState).toBe(firstVES);
+      expect(it._cache).toBe(firstCache);
+
+      await expect(first).toBeRejectedWith(error);
+
+      const firstRejected = it.valueErrorState;
+      expect(firstRejected)
+        .toBe(it.valueErrorState)
+        .toBeEqual(Rejected(undefined, error));
+      expect(it._cache).toBeUndefined();
+
+      await expect(second).toBeResolvedWith(firstRejected);
+    });
+  });
+});

--- a/src/CachedPromise.ts
+++ b/src/CachedPromise.ts
@@ -1,0 +1,90 @@
+import {SubscribableValueErrorState} from './SubscribableValueErrorState.ts';
+import type {SubjectFactory} from './Subject.ts';
+import {
+  Fulfilled,
+  Loading,
+  type Ready,
+  Rejected,
+  type ValueErrorState,
+} from './ValueErrorState.ts';
+import {type AsyncValueErrorState} from './SubscribablePromises.ts';
+
+export class CachedPromise<T, E = unknown> extends SubscribableValueErrorState<
+  T,
+  E
+> {
+  /**
+   * the implementation for handling a `request`.
+   */
+  readonly impl: () => Promise<T>;
+  constructor(
+    impl: () => Promise<T>,
+    initial: T,
+    _subjectFactory: SubjectFactory<ValueErrorState<T>>,
+  ) {
+    super(initial, _subjectFactory);
+    this.impl = impl;
+  }
+
+  /**
+   * in memory reference
+   * of the last promise returned by `impl`.
+   */
+  protected cache: Promise<T> | undefined;
+
+  /**
+   * in memory reference of the last promise returned by `impl`.
+   * @protected
+   */
+  get _cache(): Promise<T> | undefined {
+    return this.cache;
+  }
+
+  /**
+   * Provides cached access to the promise returned by `impl`.
+   * Sets `valueErrorState` to `[this.value, undefined, 'loading']`.
+   * Resolving/Rejecting will set the related state.
+   *
+   * The following actions invalidate the cache:
+   * - the promise rejects
+   * - calling `reset`
+   * - calling `refresh` when not in state `PromiseState.loading`
+   *
+   * @returns the cached ValueErrorState promise
+   */
+  async request(): AsyncValueErrorState<T, E> {
+    let p: Promise<T> | undefined;
+    try {
+      p = this.cache ?? this.impl();
+    } catch (error) {
+      this._setValueErrorState(Rejected(this.initial, error as E));
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+      return Promise.reject(error as E);
+    }
+    try {
+      if (this.cache !== p) {
+        this.cache = p;
+        this._setValueErrorState(Loading(this.value));
+      }
+      const awaited = await this.cache;
+      if (this.cache === p && this.isLoading) {
+        return this._setValueErrorState(Fulfilled(awaited));
+      }
+    } catch (error: unknown) {
+      if (this.cache === p && this.isLoading) {
+        this._setValueErrorState(Rejected(this.initial, error as E));
+        this.cache = undefined;
+        throw error;
+      }
+    }
+    // fulfills the promise with the current value, error and state,
+    // in case a new promise has been set,
+    // at the point in time `p` settles, if it ever does.
+    return this.valueErrorState;
+  }
+
+  override reset(): Ready<T> {
+    this.cache = undefined;
+    return super.reset();
+  }
+}

--- a/src/CachedPromise.ts
+++ b/src/CachedPromise.ts
@@ -66,7 +66,7 @@ export class CachedPromise<T, E = unknown> extends SubscribableValueErrorState<
         this.cache = p;
         this._setValueErrorState(Loading(this.value));
       }
-      const awaited = await this.cache;
+      const awaited = await p;
       if (this.cache === p && this.isLoading) {
         return this._setValueErrorState(Fulfilled(awaited));
       }

--- a/src/SubscribablePromises.test.ts
+++ b/src/SubscribablePromises.test.ts
@@ -9,6 +9,7 @@ import {
   Ready,
   type ValueErrorState,
 } from './ValueErrorState.ts';
+import {behaviorSubject} from '../test/behaviorSubject.ts';
 
 const givenAResolvedSubscribablePromises = async <T>(
   initial: T,
@@ -130,13 +131,11 @@ describe('SubscribablePromises', () => {
     });
     it('should be ready >-set-> loading(1) >-reject-> rejected >-set-> loading(2) >-reject-> rejected', async () => {
       const initial = false;
-      const subjectFactory = (current: ValueErrorState<boolean>) =>
-        new BehaviorSubject(current);
       const reason = new Error('promise rejected in test');
       const impl = async () => Promise.reject(reason);
       const onError = spy();
 
-      const it = new SubscribablePromises(initial, subjectFactory);
+      const it = new SubscribablePromises(initial, behaviorSubject);
 
       const first = it.set(impl(), {onError});
       expect(it.valueErrorState).toBeEqual(Loading(initial));
@@ -154,10 +153,10 @@ describe('SubscribablePromises', () => {
   });
   describe('valueErrorState$', () => {
     it('should push all possible states', async () => {
-      const subjectFactory = (current: ValueErrorState<undefined>) =>
-        new BehaviorSubject(current);
-
-      const it = new SubscribablePromises<undefined>(undefined, subjectFactory);
+      const it = new SubscribablePromises<undefined>(
+        undefined,
+        behaviorSubject,
+      );
 
       const states: PState[] = [];
       const first = it.set(Promise.resolve(undefined)); // -> loading(1)
@@ -189,9 +188,10 @@ describe('SubscribablePromises', () => {
       ] as const);
     });
     it('should be stable', () => {
-      const subjectFactory = (current: ValueErrorState<undefined>) =>
-        new BehaviorSubject(current);
-      const it = new SubscribablePromises(undefined, subjectFactory);
+      const it = new SubscribablePromises<undefined>(
+        undefined,
+        behaviorSubject,
+      );
 
       const observable = it.getValueErrorState$();
 

--- a/src/SubscribableValueErrorState.test.ts
+++ b/src/SubscribableValueErrorState.test.ts
@@ -1,15 +1,13 @@
 import {assertType, type IsExact} from '@std/testing/types';
 import {spy} from 'sinon';
-import {BehaviorSubject} from 'rxjs';
 import {describe, it, expect} from '../test/runner.ts';
 import {SubscribableValueErrorState} from './SubscribableValueErrorState.ts';
 import {Fulfilled, Loading, type ValueErrorState} from './ValueErrorState.ts';
+import {behaviorSubject} from '../test/behaviorSubject.ts';
 
 describe('SubscribableValueErrorState', () => {
   it('should not call the subjectFactory until subject is requested', () => {
-    const subjectFactory = spy(
-      (current: ValueErrorState<number>) => new BehaviorSubject(current),
-    );
+    const subjectFactory = spy(behaviorSubject<number>);
 
     const it = new SubscribableValueErrorState(0, subjectFactory);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export type * from './Subject.ts';
+export * from './CachedPromise.ts';
 export * from './ValueErrorState.ts';
 export * from './ValueErrorStates.ts';
 export * from './SubscribablePromises.ts';

--- a/test/behaviorSubject.ts
+++ b/test/behaviorSubject.ts
@@ -1,0 +1,6 @@
+import {BehaviorSubject} from 'rxjs';
+import type {ValueErrorState} from '../src/index.ts';
+
+export const behaviorSubject = <T, E = unknown>(
+  current: ValueErrorState<T, E>,
+): BehaviorSubject<ValueErrorState<T, E>> => new BehaviorSubject(current);


### PR DESCRIPTION
A `CachedPromise` keeps a reference to the promise returned by the invoked implementation,
so multiple `request`s resolve with the same ValueErrorState.